### PR TITLE
Replace old geoips.dev calls with geoips.interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@
     # # # for more details. If you did not receive the license, for more information see:
     # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 
+## NRLMMD-GEOIPS/geoips#69: 2023-02-06, update for interface class module plugins
+### Refactor
+* Replace reader and algorithm functions with geoips.interfaces calls
+* Remove unused imports
+```
+modified: data_fusion/interface_modules/procflows/data_fusion.py
+```
+* Replace colormap functions with geoips.interfaces calls
+```
+modified: data_fusion/interface_modules/output_formats/layered_imagery.py
+```
 
 # v1.6.0: 2022-11-28, open source release updates
 ## GEOIPS#119: 2022-11-17, standardize README

--- a/data_fusion/interface_modules/output_formats/layered_imagery.py
+++ b/data_fusion/interface_modules/output_formats/layered_imagery.py
@@ -23,7 +23,6 @@ from geoips.interface_modules.procflows.single_source import plot_data
 
 # New geoips interface classes
 from geoips.interfaces import colormaps
-# from geoips.dev.cmap import get_cmap
 
 # Old geoips YAML based plugins not yet implemented as class-based plugins
 from geoips.dev.product import get_cmap_name, get_cmap_args

--- a/data_fusion/interface_modules/output_formats/layered_imagery.py
+++ b/data_fusion/interface_modules/output_formats/layered_imagery.py
@@ -20,8 +20,13 @@ from geoips.image_utils.mpl_utils import create_figure_and_main_ax_and_mapobj
 from geoips.image_utils.mpl_utils import save_image, plot_overlays
 from geoips.image_utils.mpl_utils import set_title, create_colorbar
 from geoips.interface_modules.procflows.single_source import plot_data
+
+# New geoips interface classes
+from geoips.interfaces import colormaps
+# from geoips.dev.cmap import get_cmap
+
+# Old geoips YAML based plugins not yet implemented as class-based plugins
 from geoips.dev.product import get_cmap_name, get_cmap_args
-from geoips.dev.cmap import get_cmap
 from geoips.sector_utils.utils import is_sector_type
 
 LOG = logging.getLogger(__name__)
@@ -80,7 +85,7 @@ def get_arg(xobj, arg_type, dataset_name, arg_name):
 def get_final_mpl_colors_info(xobj, dataset_name, product_name, source_name):
 
     cmap_func_name = get_cmap_name(product_name, source_name)
-    cmap_func = get_cmap(cmap_func_name)
+    cmap_func = colormaps.get_plugin(cmap_func_name)
     cmap_args = get_cmap_args(product_name, source_name)
     mpl_colors_info = cmap_func(**cmap_args)
 

--- a/data_fusion/interface_modules/procflows/data_fusion.py
+++ b/data_fusion/interface_modules/procflows/data_fusion.py
@@ -16,11 +16,23 @@ import logging
 
 import xarray
 
-from geoips.dev.alg import get_alg, get_alg_type
-from geoips.dev.product import get_alg_name, get_required_variables, get_alg_args, get_product_type
-from geoips.dev.product import get_interp_name, get_interp_args, get_product
-from geoips.dev.output import get_outputter, get_outputter_type
-from geoips.dev.interp import get_interp
+# New class-based interfaces
+from geoips.interfaces import algorithms
+from geoips.interfaces import readers
+# from geoips.dev.alg import get_alg, get_alg_type
+# # from geoips.dev.output import get_outputter, get_outputter_type  # not used
+# # from geoips.dev.interp import get_interp  # not actually used
+# from geoips.stable.reader import get_reader
+
+# Old interfaces (YAML, not updated to classes yet!)
+from geoips.dev.product import get_alg_name, get_required_variables, get_alg_args
+from geoips.dev.product import get_product, get_product_type
+# from geoips.dev.product import get_interp_name, get_interp_args  # unused
+# from geoips.dev.gridlines import get_gridlines, set_lonlat_spacing  # unused
+# from geoips.dev.boundaries import get_boundaries  # unused
+
+
+# Direct imports from single_source
 from geoips.interface_modules.procflows.single_source import pad_area_definition, get_alg_xarray
 from geoips.geoips_utils import copy_standard_metadata
 from data_fusion.commandline.args import check_command_line_args
@@ -63,8 +75,6 @@ def get_overall_end_datetime(fuse_dict):
 
 def unpack_fusion_arguments(argdict):
 
-    from geoips.stable.reader import get_reader
-
     fusion_files = argdict['fuse_files']
     fusion_readers = argdict['fuse_reader_name']
     fusion_products = argdict['fuse_product_name']
@@ -85,7 +95,7 @@ def unpack_fusion_arguments(argdict):
         fusion_reader_name = fusion_readers[curr_num]
         fusion_product_name = fusion_products[curr_num]
         fusion_dataset_name = fusion_dataset_names[curr_num]
-        reader_func = get_reader(fusion_reader_name)
+        reader_func = readers.get_plugin(fusion_reader_name)
         meta = reader_func(fusion_file_list, metadata_only=True)
         source_name = meta['METADATA'].attrs['source_name']
 
@@ -270,8 +280,8 @@ def get_fused_xarray(area_def, fuse_data):
 
 
 def run_fuse_alg(fuse_xarrays, fuse_product_name, fuse_source_name):
-    alg_func = get_alg(get_alg_name(fuse_product_name, fuse_source_name))
-    alg_func_type = get_alg_type(get_alg_name(fuse_product_name, fuse_source_name))
+    alg_func = algorithms.get_plugin(get_alg_name(fuse_product_name, fuse_source_name))
+    alg_func_type = alg_func.family
     alg_args = get_alg_args(fuse_product_name, fuse_source_name)
 
     # alg_xarray will either be a single xarray Dataset, or a dictionary of xarray Datasets.
@@ -318,11 +328,6 @@ def data_fusion(fnames, command_line_args=None):
 
     compare_path = command_line_args['compare_path']
 
-    from geoips.dev.gridlines import get_gridlines, set_lonlat_spacing
-    from geoips.dev.boundaries import get_boundaries
-
-    from geoips.stable.reader import get_reader
-    from geoips.dev.product import get_required_variables
     fuse_data = unpack_fusion_arguments(command_line_args)
     final_product_name = fuse_data['final']['product_name']
     final_source_name = fuse_data['final']['source_name']

--- a/data_fusion/interface_modules/procflows/data_fusion.py
+++ b/data_fusion/interface_modules/procflows/data_fusion.py
@@ -19,18 +19,10 @@ import xarray
 # New class-based interfaces
 from geoips.interfaces import algorithms
 from geoips.interfaces import readers
-# from geoips.dev.alg import get_alg, get_alg_type
-# # from geoips.dev.output import get_outputter, get_outputter_type  # not used
-# # from geoips.dev.interp import get_interp  # not actually used
-# from geoips.stable.reader import get_reader
 
 # Old interfaces (YAML, not updated to classes yet!)
 from geoips.dev.product import get_alg_name, get_required_variables, get_alg_args
 from geoips.dev.product import get_product, get_product_type
-# from geoips.dev.product import get_interp_name, get_interp_args  # unused
-# from geoips.dev.gridlines import get_gridlines, set_lonlat_spacing  # unused
-# from geoips.dev.boundaries import get_boundaries  # unused
-
 
 # Direct imports from single_source
 from geoips.interface_modules.procflows.single_source import pad_area_definition, get_alg_xarray


### PR DESCRIPTION
# Reviewer Checklist
https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md

# Related Issues
fixes NRLMMD-GEOIPS/geoips#69

# Testing Instructions
`$GEOIPS/tests/test_full_install.sh`

(Actual data_fusion call is last: `$GEOIPS_PACKAGES_DIR/data_fusion/tests/scripts/layered.sh`)

# Summary
## NRLMMD-GEOIPS/geoips#69: 2023-02-06, update for interface class module plugins
### Refactor
* Replace reader and algorithm functions with geoips.interfaces calls
* Remove unused imports
```
modified: data_fusion/interface_modules/procflows/data_fusion.py
```
* Replace colormap functions with geoips.interfaces calls
```
modified: data_fusion/interface_modules/output_formats/layered_imagery.py
```

# Output
```
06_124356 run_procflow  63   INFO: Completed geoips PROCFLOW data_fusion processing, done!
06_124356 run_procflow  67   INFO: Starting time: 2023-02-06 20:43:29.200488
06_124356 run_procflow  68   INFO: Ending time: 2023-02-06 20:43:56.731357
06_124356 run_procflow  69   INFO: Total time: 0:00:27.530919
06_124356 run_procflow  89   INFO: Return value: 0

Package: geoips_full
Total run time: 1520 seconds
Number data types run: 43
Number data types failed: 0
```