### PR TITLE
Update import from geoips.dev.utils -> geoips_utils

### DIFF
--- a/data_fusion/plugins/modules/procflows/data_fusion.py
+++ b/data_fusion/plugins/modules/procflows/data_fusion.py
@@ -528,7 +528,7 @@ def call(fnames, command_line_args=None):
             #                                                        sect_xarrays[0].source_name,product_name))
 
     process_datetimes["overall_end"] = datetime.utcnow()
-    from geoips.dev.utils import output_process_times
+    from geoips.geoips_utils import output_process_times
 
     output_process_times(process_datetimes, num_jobs)
 

--- a/docs/source/releases/v1_10_0a1.rst
+++ b/docs/source/releases/v1_10_0a1.rst
@@ -26,6 +26,18 @@ Version 1.10.0a1 (2023-04-30)
 Breaking Changes
 ================
 
+Import output_process_times from geoips.geoips_utils
+----------------------------------------------------
+
+*From NRLMMD-GEOIPS/geoips#206: 2023-04-30, update plugin format*
+
+In preparation for removing geoips.dev.utils, moved standard utilities from
+geoips.dev.utils to geoips.geoips_utils.
+
+::
+
+  modified: data_fusion/plugins/modules/procflows/data_fusion.py
+
 Add required attributes to module-based plugins
 -----------------------------------------------
 


### PR DESCRIPTION
This is in conjunction with NRLMMD-GEOIPS/geoips#74, where imports were changed from geoips.dev.utils to geoips.geoips_utils