### PR TITLE
v1.11.3 data_fusion - VERSION RELEASE - formatting updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,8 +10,19 @@
  | # # # for more details. If you did not receive the license, for more information see:
  | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 
-Please see geoips/CHANGELOG_TEMPLATE.rst for instructions on updating
-CHANGELOG appropriately with each PR
+Please see
+``$GEOIPS_PACKAGES_DIR/geoips/CHANGELOG_TEMPLATE.rst``
+for instructions on updating CHANGELOG appropriately
+with each PR.
 
-Release notes for previous/upcoming versions can be found in
-docs/source/releases, for reference.
+The release note that is currently, actively being updated in
+all geoips plugin repositories can be found in the file
+``$GEOIPS_PACKAGES_DIR/geoips/update_this_release_note``.
+
+You can either:
+
+* update the appropriate release note in this repo directly.
+* or update this ``CHANGELOG.rst`` file with your release
+  notes, for simplicity (your notes will be moved to the
+  appropriate release note in ``docs/source/releases``
+  during the PR process)

--- a/data_fusion/commandline/args.py
+++ b/data_fusion/commandline/args.py
@@ -26,21 +26,21 @@ def check_command_line_args(arglist, argdict):
 
     Parameters
     ----------
-        arglist : list
-            * List of desired command line arguments to check within
-              argdict for appropriate formatting
-        argdict : dict
-            * Dictionary of command line arguments
+    arglist : list of str
+        List of desired command line arguments to check within
+        argdict for appropriate formatting
+    argdict : dict
+        Dictionary of command line arguments
 
     Returns
     -------
-        bool
-            * Return True if all arguments are of appropriate formatting.
+    bool
+        Return True if all arguments are of appropriate formatting.
 
     Raises
     ------
-        TypeError
-            * Incorrect command line formatting
+    TypeError
+        Incorrect command line formatting
     """
     geoips_check = geoips_check_args(arglist, argdict)
 
@@ -172,16 +172,17 @@ def get_command_line_args(arglist=None, description=None):
 
     Parameters
     ----------
-        arglist list, default=None.
-            * list of requested arguments to add to the ArgumentParser
-                * if None, include all arguments
-        description str, default=None
-            * String description of arguments
+    arglist : list, default=None
+        list of requested arguments to add to the ArgumentParser
+
+        * if None, include all arguments
+    description : str, default=None
+        String description of arguments
 
     Returns
     -------
-        dict
-            * Dictionary of command line arguments
+    dict
+        Dictionary of command line arguments
     """
     return geoips_get_args(
         arglist,
@@ -197,15 +198,16 @@ def add_args(parser, arglist=None):
 
     Parameters
     ----------
-        parser : ArgumentParser
-            * argparse ArgumentParser to add appropriate arguments
-        arglist : list, default=None
-            * list of requested arguments to add to the ArgumentParser
-                * if None, include all arguments
+    parser : ArgumentParser
+        argparse ArgumentParser to add appropriate arguments
+    arglist : list, default=None
+        list of requested arguments to add to the ArgumentParser
+
+        * if None, include all arguments
 
     Returns
     -------
-        No return values (parser modified in place)
+    No return values (parser modified in place)
     """
     geoips_add_args(parser, arglist)
 

--- a/data_fusion/plugins/modules/algorithms/stitched.py
+++ b/data_fusion/plugins/modules/algorithms/stitched.py
@@ -30,16 +30,22 @@ def call(xarray_dict, parallax_correction=True, satzen_correction=True):
 
     Parameters
     ----------
-        xobj : xarray.dataset
-            * list of numpy.ndarray or numpy.MaskedArray of channel data,
-              in order of sensor "channels" list
-            * Degrees Kelvin
+    xobj : dict of xarray.Dataset
+        Dictionary of xarray datasets, one dataset for each satellite/sensor
+        that will be stitched into the final image.
+    parallax_correction : bool, default=True
+        Not currently implemented, will provide mechanism for reducing blurriness
+        between satellites.  Currently just turns off MSG-1 in favor of Himawari-8.
+    satzen_correction : bool, default=True
+        If True, implement satellite zenith correction between satellites, giving
+        precedence to the satellite that is closer to center of scan.  Without
+        parallax correction, this causes some blurriness in the overlap region
+        between satellites where there are high clouds.
 
     Returns
     -------
-        numpy.ndarray
-            * dstacked numpy.ndarrays or numpy.MaskedArrays containing:
-                * np.ma.dstack((pcb_mask, mod_mask, bt110, bt110_night)).squeeze()
+    xarray.Dataset
+        xarray Dataset containing the final stitched dataset.
     """
     # This will change when blending polar!!
     metadata_xobj = xarray_dict.pop("METADATA")

--- a/data_fusion/plugins/modules/procflows/data_fusion.py
+++ b/data_fusion/plugins/modules/procflows/data_fusion.py
@@ -457,23 +457,25 @@ def call(fnames, command_line_args=None):
 
     Parameters
     ----------
-        fnames : list of strings
-            * List of strings specifying full paths to input file names to process
-        command_line_args (dict) :
-            * dictionary of command line arguments
-                * 'reader_name': Explicitly request reader
-                    * geoips*.readers.readername.readername
-                * Optional: 'sector_list': list of YAML sectorfiles
-                    * tc<YYYY><BASIN><NUM><NAME> for TCs,
-                      ie tc2020sh16gabekile
-                      If sectorfiles and sectorlist not included,
-                      looks in database
+    fnames : list of strings
+        List of strings specifying full paths to input file names to process
+    command_line_args : dict, default=None
+        dictionary of command line arguments
+
+          'reader_name': Explicitly request reader
+
+          *  geoips*.readers.readername.readername
+
+          Optional: 'sector_list': list of str sector names
+
+          * tc<YYYY><BASIN><NUM><NAME> for TCs,
+            ie tc2020sh16gabekile
 
     Returns
     -------
-        list
-            * Return list of strings specifying full paths to output products
-              that were produced.
+    list
+        Return list of strings specifying full paths to output products
+        that were produced.
     """
     from datetime import datetime
 

--- a/docs/source/releases/v1_11_2.rst
+++ b/docs/source/releases/v1_11_2.rst
@@ -1,0 +1,38 @@
+ | # # # Distribution Statement A. Approved for public release. Distribution unlimited.
+ | # # #
+ | # # # Author:
+ | # # # Naval Research Laboratory, Marine Meteorology Division
+ | # # #
+ | # # # This program is free software: you can redistribute it and/or modify it under
+ | # # # the terms of the NRLMMD License included with this program. This program is
+ | # # # distributed WITHOUT ANY WARRANTY; without even the implied warranty of
+ | # # # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the included license
+ | # # # for more details. If you did not receive the license, for more information see:
+ | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
+
+Version 1.11.2 (2023-09-08)
+***************************
+
+* resolve PDF build error
+
+Bug Fixes
+=========
+
+resolve PDF build error
+-----------------------
+
+Build success with pdf build automatically completing and produces a PDF.
+Resolved so PDF and html builds BOTH return zero, which equates to
+error free.
+
+The PDF build errors were caused by slightly mis-formatted RST docstrings
+in some modules, mostly due to incorrectly formatted lists.  I am not
+entirely sure why the flake8 RST docstring linting and the sphinx html
+build both did not pick up on these formatting errors, but the sphinx
+pdf build did.
+
+::
+
+  modified: data_fusion/commandline/args.py
+  modified: data_fusion/plugins/modules/algorithms/stitched.py
+  modified: data_fusion/plugins/modules/procflows/data_fusion.py

--- a/docs/source/releases/v1_11_3.rst
+++ b/docs/source/releases/v1_11_3.rst
@@ -10,58 +10,19 @@
  | # # # for more details. If you did not receive the license, for more information see:
  | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 
-.. _release_notes:
+Version 1.11.3 (2023-09-20)
+**************************************
 
-*************
-Release Notes
-*************
+Release Updates
+===============
 
-Version 1.11
-------------
+Add 1.11.3 release note
+---------------------------
 
-.. toctree::
-   :maxdepth: 1
+*From issue GEOIPS#363: 2023-09-20, version update*
 
-   v1_11_3
-   v1_11_3a0
-   v1_11_2
-   v1_11_1
-   v1_11_0
+::
 
-Version 1.10
-------------
-
-.. toctree::
-   :maxdepth: 1
-
-   v1_10_3
-   v1_10_2
-   v1_10_0
-   v1_10_0a2
-   v1_10_0a1
-   v1_10_0a0
-
-Version 1.9
------------
-
-.. toctree::
-   :maxdepth: 1
-
-   v1_9_0
-
-Version 1.8
------------
-
-.. toctree::
-   :maxdepth: 1
-
-   v1_8_1
-   v1_8_0
-
-Version 1.7
------------
-
-.. toctree::
-   :maxdepth: 1
-
-   v1_7_0
+    modified: CHANGELOG.rst
+    new file: docs/source/releases/v1_11_3.rst
+    modified: docs/source/releases/index.rst

--- a/tests/test_all.sh
+++ b/tests/test_all.sh
@@ -39,7 +39,7 @@ echo ""
 # Note you must use the variable "call" in the for the loop
 # "call" used in test_all_run.sh
 for call in \
-  "$GEOIPS_PACKAGES_DIR/geoips/tests/utils/check_code.sh all $repopath no_flake8" \
+  "$GEOIPS_PACKAGES_DIR/geoips/tests/utils/check_code.sh all $repopath" \
   "$GEOIPS_PACKAGES_DIR/geoips/docs/build_docs.sh $repopath $pkgname html_only" \
   "$GEOIPS_PACKAGES_DIR/data_fusion/tests/scripts/geo.sh Infrared-Gray" \
   "$GEOIPS_PACKAGES_DIR/data_fusion/tests/scripts/layered.sh"


### PR DESCRIPTION
# Related Issues
required to close NRLMMD-GEOIPS/geoips#346
required to close NRLMMD-GEOIPS/geoips#341

# Reviewer Instructions
* Please confirm merge is into 'main' branch from 'v1.11.3-release'
* Review "Files changed" tab
* Confirm appropriate testing was completed for these updates.

# Summary
Changes for version 1.11.3 update on repo data_fusion.
See release notes.

See NRLMMD-GEOIPS/geoips#346 for additional repositories included in this update.
See NRLMMD-GEOIPS/geoips#341 for dev updates included in this update.

# Testing Instructions
<!-- Remove this section if this is a repo without tests-->
Install GEOIPS and clone v1.11.3-release branch for:
* data_fusion
<!-- include additional repositories that must also be updated for tests to pass -->

Tests should return 0:
# The 'full_test.sh' will test ALL repos and test data available on github.com
$GEOIPS_PACKAGES_DIR/geoips/tests/integration_tests/full_test.sh
# Potentially only a subset of the 'test_all.sh' tests in each repo will work:
$GEOIPS_PACKAGES_DIR/data_fusion/tests/test_all.sh

# Output
<!-- Remove this section if this is a repo without outputs -->
<!-- Copy/paste appropriate output here if you installed and ran updates on open source -->

# Post Merge Steps
Once this PR has been merged, v1.11.3 will be tagged/released on the data_fusion main branch.