### PR TITLE
Fix Missing Docstrings (from 389 create plugin registry class)

### DIFF
--- a/data_fusion/plugins/yaml/products/layered.yaml
+++ b/data_fusion/plugins/yaml/products/layered.yaml
@@ -42,13 +42,21 @@ spec:
             colorbar: True
     - name: Layered-Winds-Horizontal-Adjust
       source_names: ["layered"]
+      docstring: |
+        Layered winds product using horizontal adjust colorbar placement.
       product_defaults: Layered-Winds-Horizontal-Adjust
     - name: Layered-Winds-Vertical-Default
       source_names: ["layered"]
+      docstring: |
+        Layered winds product using Vertical Default colorbar placement.
       product_defaults: Layered-Winds-Vertical-Default
     - name: Layered-Winds-Vertical-Adjust
       source_names: ["layered"]
+      docstring: |
+        Layered winds product using Vertical Adjust colorbar placement.
       product_defaults: Layered-Winds-Vertical-Adjust
     - name: Layered-Winds-Horizontal-and-Vertical
       source_names: ["layered"]
+      docstring: |
+        Layered winds product using Horizontal and Vertical colorbar placement.
       product_defaults: Layered-Winds-Horizontal-and-Vertical

--- a/docs/source/releases/v1_11_7a0.rst
+++ b/docs/source/releases/v1_11_7a0.rst
@@ -14,6 +14,21 @@ Version 1.11.7a0 (2023-10-06)
 *****************************
 
 * Refactor: Update data_fusion to use 'output_checkers' interface.
+* Bug Fixes: Update layered.yaml to include docstrings for each product plugins
+
+Bug Fixes
+=========
+
+*Stems from issue GEOIPS#389: 2023-10-26, Make better use of the plugin registry*
+
+With testing now added to the PluginRegistry class, we found an error in data_fusion
+where the product plugin *layered.yaml* was missing docstrings for some of its
+sub-products. This update fixes that issue, and adds docstrings to the plugins that were
+missing them.
+
+::
+
+    modified: data_fusion/data_fusion/plugins/yaml/products/layered.yaml
 
 Refactoring Updates
 ===================


### PR DESCRIPTION
# Reviewer Checklist

* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] NO REQUIRED ***unit tests*** (explain why not required)
* [x] NO REQUIRED ***integration tests*** (explain why not required)
* [x] Required ***documentation*** added for new/modified functionality
* [x] Required ***release notes*** added for new/modified functionality
* [x] NO REQUIRED ***updates to other repos*** (explain why not required)

# Related Issues
fixes NRLMMD-GEOIPS/geoips#389
stems from NRLMMD-GEOIPS/geoips#392

# Summary
With testing now added to the PluginRegistry class, we found an error in data_fusion
where the product plugin *layered.yaml* was missing docstrings for some of its
sub-products. This update fixes that issue, and adds docstrings to the plugins that were
missing them.

    modified: data_fusion/data_fusion/plugins/yaml/products/layered.yaml
