### PR TITLE
v1.12.0 data_fusion - VERSION RELEASE - separate identify_checker and get_plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 ####################################################
 # GeoIPS Environment specific .gitignore options:
 
+# auto-generated plugin registry file
+registered_plugins.json
 # auto-generated version file, created at run-time
 _version.py
 # auto-generated diff images for test outputs

--- a/data_fusion/plugins/modules/procflows/data_fusion.py
+++ b/data_fusion/plugins/modules/procflows/data_fusion.py
@@ -22,6 +22,7 @@ from geoips.errors import PluginError
 from geoips.interfaces import algorithms
 from geoips.interfaces import readers
 from geoips.interfaces import products
+from geoips.interfaces import output_checkers
 
 from geoips.filenames.duplicate_files import remove_duplicates
 
@@ -526,7 +527,9 @@ def call(fnames, command_line_args=None):
     # with the best-available information.
     # The METADATA will be updated once all algorithms/products have been applied.
     area_defs = get_area_defs_from_command_line_args(
-        command_line_args, {"METADATA": fuse_data["final"]["metadata_xobj"]}
+        command_line_args,
+        {"METADATA": fuse_data["final"]["metadata_xobj"]},
+        filter_time=True,
     )
 
     output_checker_kwargs = command_line_args.get("output_checker_kwargs", {})
@@ -625,10 +628,9 @@ def call(fnames, command_line_args=None):
     retval = 0
 
     if compare_path:
-        from geoips.interfaces.module_based.output_checkers import output_checkers
-
         for output_product in final_products:
-            output_checker = output_checkers.get_plugin(output_product)
+            plugin_name = output_checkers.identify_checker(output_product)
+            output_checker = output_checkers.get_plugin(plugin_name)
             kwargs = {}
             if output_checker.name in output_checker_kwargs:
                 kwargs = output_checker_kwargs[output_checker.name]

--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -16,18 +16,28 @@
 Release Notes
 *************
 
+Version 1.12
+------------
+
+.. toctree::
+   :maxdepth: 1
+
+   v1_12_0
+
 Version 1.11
 ------------
 
 .. toctree::
    :maxdepth: 1
 
+   v1_11_7
+   v1_11_7a0
+   v1_11_6
    v1_11_3
    v1_11_3a0
    v1_11_2
    v1_11_1
    v1_11_0
-   v1_11_7a0
 
 Version 1.10
 ------------

--- a/docs/source/releases/v1_11_6.rst
+++ b/docs/source/releases/v1_11_6.rst
@@ -10,19 +10,22 @@
  | # # # for more details. If you did not receive the license, for more information see:
  | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 
-Version 1.11.3 (2023-09-20)
+Version 1.11.6 (2023-10-26)
 ***************************
 
-Release Updates
-===============
+* Allow returning a single TC storm time rather than full list
 
-Add 1.11.3 release note
------------------------
+Bug fixes
+=========
 
-*From issue GEOIPS#363: 2023-09-20, version update*
+Allow returning a single TC storm time rather than full list
+------------------------------------------------------------
+
+Add filter_time=True to the get_area_defs_from_command_line_args
+call.  This allows returning only a single TC storm time, rather
+than the full list (to mirror how TC sectors are handled in single
+source procflow).
 
 ::
 
-    modified: CHANGELOG.rst
-    new file: docs/source/releases/v1_11_3.rst
-    modified: docs/source/releases/index.rst
+  modified: data_fusion/plugins/modules/procflows/data_fusion.py

--- a/docs/source/releases/v1_11_7.rst
+++ b/docs/source/releases/v1_11_7.rst
@@ -10,19 +10,19 @@
  | # # # for more details. If you did not receive the license, for more information see:
  | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 
-Version 1.11.3 (2023-09-20)
+Version 1.11.7 (2023-11-07)
 ***************************
 
 Release Updates
 ===============
 
-Add 1.11.3 release note
+Add 1.11.7 release note
 -----------------------
 
-*From issue GEOIPS#363: 2023-09-20, version update*
+*From issue GEOIPS#393: 2023-11-07, version update*
 
 ::
 
     modified: CHANGELOG.rst
-    new file: docs/source/releases/v1_11_3.rst
+    new file: docs/source/releases/v1_11_7.rst
     modified: docs/source/releases/index.rst

--- a/docs/source/releases/v1_12_0.rst
+++ b/docs/source/releases/v1_12_0.rst
@@ -1,0 +1,60 @@
+ | # # # Distribution Statement A. Approved for public release. Distribution unlimited.
+ | # # #
+ | # # # Author:
+ | # # # Naval Research Laboratory, Marine Meteorology Division
+ | # # #
+ | # # # This program is free software: you can redistribute it and/or modify it under
+ | # # # the terms of the NRLMMD License included with this program. This program is
+ | # # # distributed WITHOUT ANY WARRANTY; without even the implied warranty of
+ | # # # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the included license
+ | # # # for more details. If you did not receive the license, for more information see:
+ | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
+
+Version 1.12.0 (2023-12-14)
+***************************
+
+* Bug fixes
+
+  * Call identify_checker and get_plugin separately for output_checkers
+
+Bug Fixes
+=========
+
+Call identify_checker and get_plugin separately for output_checkers
+-------------------------------------------------------------------
+
+*From GEOIPS#422: 2023-12-14, 1.12.0 release bug fixes*
+
+* Call identify checker and get_plugin separately from procflows
+
+  * Rather than having a special case in base.py get_plugin and
+    output_checkers get_plugin which allowed passing in full paths
+    to output products and automatically identifying the checker
+    name and opening it, just explicitly call ``identify_checker``
+    and ``get_plugin`` separately from the procflows.
+  * single_source, config_based, and data_fusion procflows all now
+    call ``identify_checker`` on the output product filename, and
+    ``get_plugin`` on the resulting checker plugin name.
+  * This simplified a lot of logic in both ``output_checkers`` and
+    ``interfaces/base.py``. Supporting passing a filename to
+    ``output_checkers.get_plugin()`` was unnecessarily complicated.
+
+::
+
+  M geoips/plugins/modules/procflows/data_fusion.py
+
+Release Process
+===============
+
+Add release note for v1.12.0
+----------------------------
+
+*From GEOIPS#422: 2023-12-14, 1.12.0 release process updates*
+
+All updates until the next release (v1.12.0) will be included in
+this release note.
+
+::
+
+  modified: docs/source/releases/v1_12_0.rst
+  modified: docs/source/releases/index.rst


### PR DESCRIPTION
# Related Issues
required to close NRLMMD-GEOIPS/geoips#418
required to close NRLMMD-GEOIPS/geoips#402

# Reviewer Instructions
* Please confirm this PR is set up to merge from v1.12.0-release branch into main branch
* Review "Files changed" tab
* Confirm appropriate testing was completed for these updates (you may perform tests yourself, or review output included from another reviewer/assignee)

# Summary
Changes for version 1.12.0, uploaded with
1.12.0 update on repo data_fusion.
See release note updates in 'Files changed' tab

See NRLMMD-GEOIPS/geoips#418 for additional repositories included in this update.
See NRLMMD-GEOIPS/geoips#402 for dev updates included in this update.

# Testing Instructions
See NRLMMD-GEOIPS/geoips#418 for testing instructions.

# Output
See NRLMMD-GEOIPS/geoips#418 for test output.

# Post Merge Steps
Once this PR has been merged, v1.12.0
will be tagged/released on the data_fusion main branch.