### PR TITLE
428 unique product keys in registry

### DIFF
--- a/data_fusion/plugins/modules/procflows/data_fusion.py
+++ b/data_fusion/plugins/modules/procflows/data_fusion.py
@@ -210,7 +210,7 @@ def get_fused_xarray(area_def, fuse_data):
 
     final_product_name = fuse_data["final"]["product_name"]
     final_source_name = fuse_data["final"]["source_name"]
-    final_prod_plugin = products.get_plugin(final_source_name, final_product_name)
+    final_prod_plugin = products.get_plugin(f"{final_source_name}.{final_product_name}")
     final_covg_args = get_covg_args_from_product(final_prod_plugin)
 
     metadata_xobj = fuse_data["final"]["metadata_xobj"]
@@ -227,7 +227,7 @@ def get_fused_xarray(area_def, fuse_data):
         source_name = fuse_data[fuse_data_name]["source_name"]
         reader = fuse_data[fuse_data_name]["reader_func"]
         files = fuse_data[fuse_data_name]["files"]
-        prod_plugin = products.get_plugin(source_name, product_name)
+        prod_plugin = products.get_plugin(f"{source_name}.{product_name}")
         required_variables = get_required_variables(prod_plugin)
 
         # We are checking to see if there are any additional variables required
@@ -237,7 +237,7 @@ def get_fused_xarray(area_def, fuse_data):
         # satellites, etc.
         try:
             final_prod_plugin_for_curr_source = products.get_plugin(
-                source_name, final_product_name
+                f"{source_name}.{final_product_name}"
             )
             # If variables are specified within the "final_product" definition
             # in product_inputs/<source_name>.yaml, Then append them to the
@@ -259,7 +259,7 @@ def get_fused_xarray(area_def, fuse_data):
         # "fuse_product" within product_inputs/<source_name>.yaml,
         # then pad appropriately here.  If a product is missing some
         # data after reprojecting, you may need to pad.
-        prod_plugin = products.get_plugin(source_name, product_name)
+        prod_plugin = products.get_plugin(f"{source_name}.{product_name}")
 
         unsectored_product_types = [
             "unsectored_xarray_dict_to_output_format",
@@ -293,8 +293,7 @@ def get_fused_xarray(area_def, fuse_data):
 
         # Is this any different from the previous `prod_plugin?`
         prod_plugin = products.get_plugin(
-            pad_sect_xarrays["METADATA"].source_name,
-            product_name,
+            f"{pad_sect_xarrays['METADATA'].source_name}.{product_name}",
         )
         # dataset_name is {dataset_name} for uniqueness.
         dataset_name = fuse_data[fuse_data_name]["dataset_name"]
@@ -515,7 +514,7 @@ def call(fnames, command_line_args=None):
     fuse_data = unpack_fusion_arguments(command_line_args)
     final_product_name = fuse_data["final"]["product_name"]
     final_source_name = fuse_data["final"]["source_name"]
-    final_prod_plugin = products.get_plugin(final_source_name, final_product_name)
+    final_prod_plugin = products.get_plugin(f"{final_source_name}.{final_product_name}")
 
     # Set output_format and product_name in the command_line_args dict, used
     # throughout single_source code.

--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -16,6 +16,14 @@
 Release Notes
 *************
 
+Version 1.12
+------------
+
+.. toctree::
+   :maxdepth: 1
+
+   v1_12_0a0
+
 Version 1.11
 ------------
 

--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -16,13 +16,13 @@
 Release Notes
 *************
 
-Version 1.12
+Version 1.13
 ------------
 
 .. toctree::
    :maxdepth: 1
 
-   v1_12_0a0
+   v1_13_0a0
 
 Version 1.11
 ------------

--- a/docs/source/releases/v1_12_0a0.rst
+++ b/docs/source/releases/v1_12_0a0.rst
@@ -1,0 +1,38 @@
+ | # # # Distribution Statement A. Approved for public release. Distribution unlimited.
+ | # # #
+ | # # # Author:
+ | # # # Naval Research Laboratory, Marine Meteorology Division
+ | # # #
+ | # # # This program is free software: you can redistribute it and/or modify it under
+ | # # # the terms of the NRLMMD License included with this program. This program is
+ | # # # distributed WITHOUT ANY WARRANTY; without even the implied warranty of
+ | # # # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the included license
+ | # # # for more details. If you did not receive the license, for more information see:
+ | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
+
+Version 1.12.0a0 (2024-02-07)
+*****************************
+
+* Refactor: Change products.get_plugin calls to reflect new product keys in registry
+
+Refactoring Updates
+===================
+
+Update Data Fusion to use the 'output_checkers' interface
+---------------------------------------------------------
+
+*From GEOIPS#428, 2024-02-05, Sub-Products sometimes encounter duplicate top level name*
+
+GeoIPS currently stores product plugins in the registry via a combination of their
+source_names and the actual sub-product name. For instance, the entry abi["Infrared"],
+is created not because of the top level name "abi", rather it's created by each of the
+sub-product's source_names. This led to duplicate plugins being found if a file added
+an entry for a certain source name, which was later found as the top level name of
+another product. We've changed the implementation of this, and now products are stored
+via a combination of their <source_name>.<product_name>, which allows for easier access,
+and unique keys throught the product plugin registry.
+
+::
+
+    modified: data_fusion/data_fusion/plugins/modules/procflows/data_fusion.py
+

--- a/docs/source/releases/v1_13_0a0.rst
+++ b/docs/source/releases/v1_13_0a0.rst
@@ -10,7 +10,7 @@
  | # # # for more details. If you did not receive the license, for more information see:
  | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 
-Version 1.12.0a0 (2024-02-07)
+Version 1.13.0a0 (2024-06-07)
 *****************************
 
 * Refactor: Change products.get_plugin calls to reflect new product keys in registry


### PR DESCRIPTION
# Reviewer Checklist

* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] NO REQUIRED ***unit tests*** (explain why not required)
* [x] NO REQUIRED ***integration tests*** (explain why not required)
* [x] NO REQUIRED ***documentation*** (explain why not required)
* [x] Required ***release notes*** added for new/modified functionality
* [x] Required ***updates to other repos*** complete

# Related Issues
fixes NRLMMD-GEOIPS/geoips#428

# Testing Instructions
Run geoips/tests/integration_tests/full_test.sh to ensure updates are working properly.

# Summary
*From NRLMMD-GEOIPS/geoips#428, 2024-02-05, Sub-Products sometimes encounter duplicate top level name*

GeoIPS currently stores product plugins in the registry via a combination of their
source_names and the actual sub-product name. For instance, the entry abi["Infrared"],
is created not because of the top level name "abi", rather it's created by each of the
sub-product's source_names. This led to duplicate plugins being found if a file added
an entry for a certain source name, which was later found as the top level name of
another product. We've changed the implementation of this, and now products are stored
via a combination of their <source_name>.<product_name>, which allows for easier access,
and unique keys throught the product plugin registry.

    - modified: data_fusion/data_fusion/plugins/modules/procflows/data_fusion.py

