### PR TITLE
replaced all occurrences of ``matplotlib_linear_norm`` with ``linear_norm``

### DIFF
--- a/data_fusion/plugins/yaml/products/stitched.yaml
+++ b/data_fusion/plugins/yaml/products/stitched.yaml
@@ -22,7 +22,7 @@ spec:
             arguments: {}
         colormapper:
           plugin:
-            name: matplotlib_linear_norm
+            name: linear_norm
             arguments:
               data_range: [-100.0, 50.0]
               cmap_name: Greys

--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -16,6 +16,14 @@
 Release Notes
 *************
 
+Version 1.13
+------------
+
+.. toctree::
+   :maxdepth: 1
+
+   v1_13_0a0
+
 Version 1.12
 ------------
 

--- a/docs/source/releases/v1_13_0a0.rst
+++ b/docs/source/releases/v1_13_0a0.rst
@@ -1,0 +1,38 @@
+ | # # # Distribution Statement A. Approved for public release. Distribution unlimited.
+ | # # #
+ | # # # Author:
+ | # # # Naval Research Laboratory, Marine Meteorology Division
+ | # # #
+ | # # # This program is free software: you can redistribute it and/or modify it under
+ | # # # the terms of the NRLMMD License included with this program. This program is
+ | # # # distributed WITHOUT ANY WARRANTY; without even the implied warranty of
+ | # # # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the included license
+ | # # # for more details. If you did not receive the license, for more information see:
+ | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
+
+Version 1.13.0a0 (2024-04-24)
+*****************************
+
+* Refactoring Updates
+
+  * Replace all occurences of ``matplotlib_linear_norm`` to ``linear_norm``
+
+Refactoring Updates
+===================
+
+Replace all occurences of ``matplotlib_linear_norm`` to ``linear_norm``
+-----------------------------------------------------------------------
+
+*From GEOIPS#504 492 text based interface*
+
+This is a small refactoring PR that was needed due to changes included in #504. Jeremy
+and I decided that colormapper ``matplotlib_linear_norm`` wasn't the best name for that
+colormapper, as it just applies a ``linear_norm`` algorithm to colormap the data
+correctly. It is not inherently just matplotlib-based. We updated all occurences of this
+found within data_fusion.
+
+::
+
+    modified: data_fusion/plugins/yaml/products/stitched.yaml
+
+

--- a/docs/source/releases/v1_13_0a0.rst
+++ b/docs/source/releases/v1_13_0a0.rst
@@ -10,7 +10,7 @@
  | # # # for more details. If you did not receive the license, for more information see:
  | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 
-Version 1.13.0a0 (2024-04-24)
+Version 1.13.0a0 (2024-06-07)
 *****************************
 
 * Refactoring Updates


### PR DESCRIPTION
# Reviewer Checklist

* [ ] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [ ] NO REQUIRED ***unit tests*** (explain why not required)
* [ ] NO REQUIRED ***integration tests*** (explain why not required)
* [ ] NO REQUIRED ***documentation*** (explain why not required)
* [ ] Required ***release notes*** added for new/modified functionality
* [ ] Required ***updates to other repos*** complete

# Related Issues / PRs
fixes NRLMMD-GEOIPS/geoips#504
NOTE: Do not merge until NRLMMD-GEOIPS/geoips#504 has been merged, as this PR stems from that one.

# Testing Instructions
run ./data_fusion/tests/test_all.sh and get an output of 0 to know this is working correctly.

# Summary
This is a small refactoring PR that was needed due to changes included in #504. Jeremy
and I decided that colormapper ``matplotlib_linear_norm`` wasn't the best name for that
colormapper, as it just applies a ``linear_norm`` algorithm to colormap the data
correctly. It is not inherently just matplotlib-based. We updated all occurences of this
found within data_fusion.

    modified: data_fusion/plugins/yaml/products/stitched.yaml
