### PR TITLE
1.17.2 data_fusion - VERSION RELEASE - add storm startdatetime to geoips_fname test output file names.

### DIFF
--- a/docs/source/releases/1.16.1/1.16.1-open-source-upload.yaml
+++ b/docs/source/releases/1.16.1/1.16.1-open-source-upload.yaml
@@ -1,0 +1,7 @@
+Release Updates - Open Source Upload:
+- title: Open source upload
+  description: "This repo updated with current geoips version release"
+  files:
+    modified:
+    - standard sync files
+    - release notes


### PR DESCRIPTION
# NOTE
Merge this into 1.17.1, then merge 1.17.1 to main.

# Related Issues
required to close NRLMMD-GEOIPS/geoips#1170
required to close NRLMMD-GEOIPS/geoips#1170

# Reviewer Instructions
* Please confirm this PR is set up to merge from v1.17.2-version-release branch into main branch
* Review "Files changed" tab
* Confirm appropriate testing was completed for these updates (you may perform tests yourself, or review output included from another reviewer/assignee)

# Summary
Changes for version 1.17.2, uploaded with
1.17.2 update on repo data_fusion.
See release note updates in 'Files changed' tab

See NRLMMD-GEOIPS/geoips#1170 for additional repositories included in this update.
See NRLMMD-GEOIPS/geoips#1170 for dev updates included in this update.

# Testing Instructions
See NRLMMD-GEOIPS/geoips#1170 for testing instructions.

# Output
See NRLMMD-GEOIPS/geoips#1170 for test output.

# Post Merge Steps
Once this PR has been merged, 1.17.2
will be tagged/released on the data_fusion main branch.