### PR TITLE
1.19.0 data_fusion - VERSION RELEASE - sync updates only

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -682,6 +682,7 @@
         "nullval",
         "oscat",
         "outfnames",
+        "pluginify",
         "pname",
         "qux",
         "remss",

--- a/.github/workflows/status-check.yaml
+++ b/.github/workflows/status-check.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   status-check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER }}
     steps:
       - name: No-op status check
-        run: echo "No-op Actions workflow to enforce up to date branches before merge"
+        run: echo "No-op Actions workflow to allow enforcing up to date branches before merge"

--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# build mounts for dockerfile
+geoips_test_data

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,8 +3,6 @@
 
 # Contributor Covenant Code of Conduct
 
-Code of Conduct only applicable for github.com.
-
 This Code of Conduct is maintained and enforced by our community collaborators,
 and not the Federal Government and its employees.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,6 +3,8 @@
 
 # Contributor Covenant Code of Conduct
 
+Code of Conduct only applicable for github.com.
+
 This Code of Conduct is maintained and enforced by our community collaborators,
 and not the Federal Government and its employees.
 

--- a/docs/source/releases/1.19.0/1.19.0-internal-release.yaml
+++ b/docs/source/releases/1.19.0/1.19.0-internal-release.yaml
@@ -1,0 +1,12 @@
+Release Process:
+- title: Add 1.19.0 release note
+  description: |
+    Currently tagged internal version 1.18.2.
+  files:
+    added:
+    - docs/source/releases/1.19.0/1.19.0-internal-release.yaml
+  related-issue:
+    internal: data_fusion#1067 - 1.19.0 updates
+  date:
+    start: 2026-05-26
+    finish: 2026-05-26

--- a/docs/source/releases/1.19.0/1.19.0-no-bug-fixes-required-on-this-release.yaml
+++ b/docs/source/releases/1.19.0/1.19.0-no-bug-fixes-required-on-this-release.yaml
@@ -1,0 +1,17 @@
+Release Process:
+- title: No bug fixes required on this release
+  description: |
+    It's your lucky day! This release required no bug fixes that will need to be
+    tracked and merged back into the next release.  If no bug fixes are required on
+    a release branch, this file MUST be created for the release branch CI to pass.
+    If there are bug fixes, you must create patch release notes named explicitly
+
+    * docs/source/releases/X.Y.Z/X.Y.Z-patch-internal-name-description.yaml
+    * OR
+    * docs/source/releases/X.Y.Z/X.Y.Z-patch-os-name-description.yaml
+
+    If neither the patch release note nor the bug-free release note exist on a release
+    branch, the CI will fail, forcing you to decide if there were bugs or not.
+  files:
+    added:
+    - docs/source/releases/X.Y.Z/X.Y.Z-no-bug-fixes-required-on-this-release.yaml

--- a/docs/source/releases/1.19.0/1.19.0-open-source-upload.yaml
+++ b/docs/source/releases/1.19.0/1.19.0-open-source-upload.yaml
@@ -1,0 +1,7 @@
+Release Updates - Open Source Upload:
+- title: Open source upload
+  description: "This repo updated with current geoips version release"
+  files:
+    modified:
+    - standard sync files
+    - release notes

--- a/docs/source/releases/1.19.0/1.19.0-release-note.yaml
+++ b/docs/source/releases/1.19.0/1.19.0-release-note.yaml
@@ -1,0 +1,17 @@
+documentation:
+- title: Add release note for version 1.19.0
+  description: |
+    Release note on release branch to force tag/release, package/publish,
+    and deploy docs.
+
+    Additionally add any updated files from geoips_ci/sync
+  files:
+    added:
+    - docs/source/releases/latest/1.19.0-release-note.yaml
+    modified:
+    - geoips_ci/sync updated files
+  date:
+    start: 2026-06-09
+    finish: 2026-06-09
+  related-issue:
+    internal: geoips#1067 - 1.19.0 updates


### PR DESCRIPTION
# Related Issues
required to close NRLMMD-GEOIPS/geoips#1325
required to close NRLMMD-GEOIPS/geoips#1325

# Reviewer Instructions
* Please confirm this PR is set up to merge from v1.19.0-version-release branch into main branch
* Review "Files changed" tab
* Confirm appropriate testing was completed for these updates (you may perform tests yourself, or review output included from another reviewer/assignee)

# Summary
Changes for version 1.19.0, uploaded with
1.19.0 update on repo data_fusion.
See release note updates in 'Files changed' tab

See NRLMMD-GEOIPS/geoips#1325 for additional repositories included in this update.
See NRLMMD-GEOIPS/geoips#1325 for dev updates included in this update.

# Testing Instructions
See NRLMMD-GEOIPS/geoips#1325 for testing instructions.

# Output
See NRLMMD-GEOIPS/geoips#1325 for test output.

# Pre Merge Steps
* geoips repo must be merged first during the release process so all other repos reference the correct geoips version.
* geoips_ci repo must be merged second so CI is up to date for all other repos.
* Once geoips and geoips_ci are merged, then the remaining version release PRs can be merged on all remaining repos.

# Post Merge Steps
Once this PR has been merged, 1.19.0
will be tagged/released on the data_fusion main branch.